### PR TITLE
Join mission action

### DIFF
--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,7 +1,9 @@
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import styles from '../styles/Missions.module.css';
+import { joinMission } from '../redux/missions/missionsSlice';
 
 const Missions = () => {
+  const dispatch = useDispatch();
   const { missions, isLoading, error } = useSelector((store) => store.missions);
 
   if (isLoading) {
@@ -39,6 +41,7 @@ const Missions = () => {
                 <button
                   type="button"
                   className={styles.join_mission}
+                  onClick={() => dispatch(joinMission(item.mission_id))}
                 >
                   join mission
                 </button>

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -24,7 +24,17 @@ const initialState = {
 export const missionsSlice = createSlice({
   name: 'missions',
   initialState,
-  reducers: { },
+  reducers: {
+    joinMission: (state, action) => {
+      const newMissionsState = state.missions.map((mission) => {
+        if (mission.mission_id !== action.payload) {
+          return mission;
+        }
+        return { ...mission, is_member: true };
+      });
+      state.missions = newMissionsState;
+    },
+  },
   extraReducers(builder) {
     builder
       .addCase(getMissions.pending, (state) => {
@@ -49,5 +59,7 @@ export const missionsSlice = createSlice({
       });
   },
 });
+
+export const { joinMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -30,7 +30,7 @@ export const missionsSlice = createSlice({
         if (mission.mission_id !== action.payload) {
           return mission;
         }
-        return { ...mission, is_member: true };
+        return { ...mission, reserved: true };
       });
       state.missions = newMissionsState;
     },


### PR DESCRIPTION
## Hi @Lawmsangi 👋🏻 

### In this branch I implement the functionality which adds a `reserved: true` key/value pair to a mission when a user clicks `Join Mission` button.

1. I created 'joinMission' reducer in MissionsSlice.js and exported this reducer.
  The reducer looks for a mission with the same ID as provided:
    ``
    if (mission.mission_id !== action.payload) {
      return mission;
    }
    ``

    and adds  'reserved: true' key/value pair when it finds the mission with the same ID as provided:
    ``
    return mission.reserved === true
    ``

2. 'joinMission' reducer is imported into Missions component and dispatched on buttons's onClick attribute like this:
    ``
    onClick={() => dispatch(joinMission(item.mission_id))}
    ``
    
Our project so far:
https://drive.google.com/file/d/1lMZHv7v0qU458J_595G5uHkHLpNmAQqN/view?usp=sharing
