### PR TITLE
Leave mission action

### DIFF
--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -30,7 +30,8 @@ export const missionsSlice = createSlice({
         if (mission.mission_id !== action.payload) {
           return mission;
         }
-        return { ...mission, reserved: true };
+        return mission.reserved === true ? { ...mission, reserved: false }
+          : { ...mission, reserved: true };
       });
       state.missions = newMissionsState;
     },


### PR DESCRIPTION
## Hi @Lawmsangi 👋🏻
### In this branch I implement the functionality that sets a mission's `reserved` attribute to `false` when a user clicks `Join Mission` button the second time.

I modified 'joinMission' reducer:

- The reducer looks for a mission with the same ID as provided:
    ``
    if (mission.mission_id !== action.payload) {
      return mission;
    }
    ``

- When it finds a mission with the same ID as provided, it checks if this mission already has 'reserved: true' key/value pair:
    ``
    return mission.reserved === true ? { ...mission, reserved: false } : { ...mission, reserved: true };
    ``
- If 'reserved: true' key/value pair was found then we switch `true` to `false`:
    ``
    { ...mission, reserved: false }
    ``
- If 'reserved' property is set to 'false' or doesn't exist then 'reserved' property is set to 'true' or a new 'reserved: true' key/value pair is added:
    ``
    { ...mission, reserved: true };
    ``

The full process looks like this:
```
if (mission.mission_id !== action.payload) {
  return mission;
}
return mission.reserved === true ? { ...mission, reserved: false } : { ...mission, reserved: true };
```

Our project so far:
https://drive.google.com/file/d/1lMZHv7v0qU458J_595G5uHkHLpNmAQqN/view?usp=sharing